### PR TITLE
Build each distinct configuration only once

### DIFF
--- a/bin/experiment
+++ b/bin/experiment
@@ -7,6 +7,7 @@ require 'experiment'
 require 'rugged'
 require 'thwait'
 require "colorize"
+require 'tmpdir'
 
 program :name, 'experiment'
 program :version, Experiment::VERSION
@@ -28,20 +29,33 @@ command :run do |c|
 		config["repository"]  = config["repository"].gsub("~", Dir.home)
 		repo = Rugged::Repository.new(config["repository"])
 
-		versions = {}
+		# Create list of versions, organized by build
+		build_versions = Hash.new { |hash,key| hash[key] = {} }
 		config["versions"].each do |vname, version|
-			Dir.mkdir vname
-			versions[vname] = Experiment::Application.new(:wd => Dir.pwd + "/" + vname,
+			app = Experiment::Application.new(:wd => Dir.pwd + "/" + vname,
 								      :config => config,
 								      :version => version,
 								      :repo => repo)
-			versions[vname].build vname
+			build_versions[app.build][vname] = app
+		end
+
+		# Build each distinct build, then use it to initialize the relevant
+		# versions.
+		build_versions.each do |build, versions|
+			Dir.mktmpdir do |build_dir|
+				build.build(build_dir)
+				versions.each do |vname, a|
+					a.copy_build(vname, build_dir)
+				end
+			end
 		end
 
 		ops = []
 		for n in 1..config["iterations"] do
-			versions.each do |vname, a|
-				ops << [vname, a, n]
+			build_versions.values.each do |versions|
+				versions.each do |vname, a|
+					ops << [vname, a, n]
+				end
 			end
 		end
 

--- a/lib/experiment/application.rb
+++ b/lib/experiment/application.rb
@@ -3,70 +3,49 @@ require "colorize"
 require "fileutils"
 
 module Experiment
-	class Application
-		@wd
-		@config
-		@version
-		@repo
-		@args
-
-		def initialize(options = {})
-			@wd = options[:wd]
-			@config = options[:config]
-			@version = options[:version]
-			@repo = options[:repo]
-			@args = (@version["arguments"] || @config["arguments"]).dup
-			@args.each_with_index do |a, i|
-				if a.match(/^~\//)
-					@args[i] = Dir.home + a.gsub(/^~/, '')
-				end
-			end
-			@args[0] = @wd + "/source/" + @args[0]
+	class Build
+		attr_reader :command
+		attr_reader :checkout
+		attr_reader :diffs
+		def initialize(repo, command, checkout, diffs)
+			@repo = repo
+			@command = command
+			@checkout = checkout
+			@diffs = diffs || []
 		end
 
-		def build(vname)
-			commit = @repo.rev_parse(@version["checkout"] || @config["checkout"])
+		def build(wd)
+			commit = @repo.rev_parse(@checkout)
 
 			pwd = Dir.pwd
-			Dir.chdir @wd
+			Dir.chdir wd
 
-			log = File.open "experiment.log", "w"
+			# Record a build log with information about the commit being built
+			log = File.open "build.log", "w"
 			log.write "Commit: #{commit.oid}\n"
 			log.write "Parent commits: #{commit.parent_oids}\n"
 			log.write "Committed at: #{commit.time}\n"
 
-			arghashes = []
-			@args.each_with_index do |a, i|
-				if File.exists? a
-					arghashes << "\targ[#{i}] = #{a} has hash #{Digest::SHA2.file(a).hexdigest}\n"
-				end
-			end
-			if not arghashes.empty?
-				log.write "\nFile argument hashes:\n"
-				arghashes.each { |e| log.write e }
-			end
-
-			if not @version["diffs"].nil?
-				for p in @version["diffs"] do
-					log.write "\n"
-					f = File.open File.expand_path p
-					log.write f.read
-					f.close
-				end
+			# Add the text of the diffs to the build log
+			for p in @diffs do
+				log.write "\n"
+				f = File.open File.expand_path p
+				log.write f.read
+				f.close
 			end
 			log.close
 
 			Dir.mkdir "source"
 			Dir.chdir "source"
 
-			puts "==> Preparing source for version '#{vname}'".bold
+			puts "==> Preparing source for build of '#{@checkout}'".bold
 
 			puts " -> Recreating source tree".blue
 			Experiment::recreate_tree(@repo, commit)
 
-			if not @version["diffs"].nil?
+			if not @diffs.empty?
 				puts " -> Applying patches".cyan
-				for p in @version["diffs"] do
+				for p in @diffs do
 					# git apply ...
 					puts "  - #{p}".cyan
 					if system("/usr/bin/patch", "-Np1", "-i", File.expand_path(p)).nil?
@@ -93,17 +72,85 @@ module Experiment
 			end
 
 			puts " -> Building application".yellow
-			if system(@version["build"] || @config["build"]).nil?
+			if system(@command).nil?
 				raise "Build failed"
 			end
-
-			puts " -> Application version ready".green
 
 			Dir.chdir pwd
 		end
 
+
+		def ==(o)
+			o.class == self.class and
+				o.state == self.state
+		end
+
+		alias_method :eql?, :==
+		def hash
+			state.hash
+		end
+
+		def to_s
+			"Build #{@command} at #{@checkout} patched with #{@diffs}"
+		end
+
+		protected
+		def state
+			[@command, @checkout, @diffs]
+		end
+	end
+
+	class Application
+		@wd
+		@config
+		@version
+		@repo
+		@args
+		attr_reader :build
+
+		def initialize(options = {})
+			@wd = options[:wd]
+			@config = options[:config]
+			@version = options[:version]
+			@repo = options[:repo]
+			@args = (@version["arguments"] || @config["arguments"]).dup
+			@args.each_with_index do |a, i|
+				if a.match(/^~\//)
+					@args[i] = Dir.home + a.gsub(/^~/, '')
+				end
+			end
+			@args[0] = @wd + "/source/" + @args[0]
+			@build = Build.new(@repo,
+							   @version["build"] || @config["build"],
+							   @version["checkout"] || @config["checkout"],
+							   @version["diffs"])
+		end
+
+		def copy_build(vname, dir)
+			if File.exist? @wd
+				raise "Version #{vname} directory already exists"
+			end
+			FileUtils.cp_r dir, @wd
+			puts "--> Source for version '#{vname}' ready".green
+		end
+
 		def run(number)
 			Dir.chdir @wd
+			# Record an experiment log with the hashes of any input files
+			# passed on the command line.
+			log = File.open "experiment.log", "w"
+			arghashes = []
+			@args.each_with_index do |a, i|
+				if File.exists? a
+					arghashes << "\targ[#{i}] = #{a} has hash #{Digest::SHA2.file(a).hexdigest}\n"
+				end
+			end
+			if not arghashes.empty?
+				log.write "File argument hashes:\n"
+				arghashes.each { |e| log.write e }
+			end
+			log.close
+
 			Dir.mkdir "run-#{number}"
 			Dir.chdir "run-#{number}"
 


### PR DESCRIPTION
Build is performed in a temp directory, then copied to each version's
directory. Only one build's directory is present at a time.