### PR TITLE
Substitute $SRC in arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ First, define the parameters for your experiment in a directory with a
 	"build": "make -j8",
 	"keep-stdout": true,
 	"arguments": [
-		"build/bin/myapp",
+		"$SRC/build/bin/myapp",
 		"-r",
 		"3",
 		"~/experimental-data.dat"

--- a/bin/experiment
+++ b/bin/experiment
@@ -73,7 +73,11 @@ command :run do |c|
 			end
 
 			threads << Thread.new(vname, a, n) do |vname, a, n|
-				a.run(n)
+				begin
+					a.run(n)
+				rescue Exception => er
+					STDERR.puts "internal error while running version #{vname}: #{er}"
+				end
 			end
 			twait = ThreadsWait.new *threads
 			running += 1

--- a/lib/experiment/application.rb
+++ b/lib/experiment/application.rb
@@ -141,7 +141,7 @@ module Experiment
 			log = File.open "experiment.log", "w"
 			arghashes = []
 			@args.each_with_index do |a, i|
-				if File.exists? a
+				if File.file? a
 					arghashes << "\targ[#{i}] = #{a} has hash #{Digest::SHA2.file(a).hexdigest}\n"
 				end
 			end


### PR DESCRIPTION
Replaced with full path to source directory for the application version.
Currently only arguments is substituted, but this change also creates the
infrastructure to provide substitution of any environment variable into many of
the other config keys (eg, the build command could use it).

A further followup would be to add a key for environment variables to modify
for the build or run, which would themselves have substitutions performed. This
feature is really only motivated by Go, where building requires that GOPATH be
set correctly somehow.