### PR TITLE
Fix bug with hashing non-file paths in args

### DIFF
--- a/lib/experiment/application.rb
+++ b/lib/experiment/application.rb
@@ -141,7 +141,7 @@ module Experiment
 			log = File.open "experiment.log", "w"
 			arghashes = []
 			@args.each_with_index do |a, i|
-				if File.exists? a
+				if File.file? a
 					arghashes << "\targ[#{i}] = #{a} has hash #{Digest::SHA2.file(a).hexdigest}\n"
 				end
 			end


### PR DESCRIPTION
The SHA2 digest would fail and throw a Ruby exception, preventing the
application version from ever running. Fixed by only hashing regular
files that exist (in particular, not trying to hash directories and
special files).