### PR TITLE
Catch internal Ruby errors while running app

### DIFF
--- a/bin/experiment
+++ b/bin/experiment
@@ -72,7 +72,11 @@ command :run do |c|
 			end
 
 			threads << Thread.new(vname, a, n) do |vname, a, n|
-				a.run(n)
+				begin
+					a.run(n)
+				rescue Exception => er
+					STDERR.puts "internal error while running version #{vname}: #{er}"
+				end
 			end
 			twait = ThreadsWait.new *threads
 			running += 1


### PR DESCRIPTION
Running inside a thread masks uncaught exceptions. This change exposes
the error on experiment's stderr.