### PR TITLE
Require build in top-level library

### DIFF
--- a/lib/experiment.rb
+++ b/lib/experiment.rb
@@ -1,4 +1,5 @@
 require 'experiment/version'
 require 'experiment/config'
+require 'experiment/build'
 require 'experiment/application'
 require 'experiment/recreate_tree'


### PR DESCRIPTION
Experiment.Application depends on both the substitute helper method and
the Build class defined in build.rb.